### PR TITLE
Fetch a single bill detail via the OpenStates id

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ You can also search for a specific bill by it's bill_id.
 bill = OpenStates::Bill.find("12345")
 ```
 
+Or by its OpenStates `id`.
+
+```rb
+bill = OpenStates::Bill.find_by_openstates_id("KS00012345")
+```
+
 And lastly, you can get bill details by using the `bill_details` class
 method on OpenStates::Bill.
 

--- a/lib/openstates/api.rb
+++ b/lib/openstates/api.rb
@@ -18,6 +18,11 @@ module OpenStates
       get(url, options)
     end
 
+    def bill(os_id)
+      url = "bills/#{os_id}/"
+      get(url, {})
+    end
+
     def legislators(options = {})
       url = "legislators/"
       url << "#{options[:leg_id]}/" if options[:leg_id]

--- a/lib/openstates/models/bill.rb
+++ b/lib/openstates/models/bill.rb
@@ -48,6 +48,12 @@ module OpenStates
 
         from_hash(response)
       end
+
+      def find_by_openstates_id(os_id)
+        response = OpenStates.bill(os_id)
+
+        from_hash(response)
+      end
     end
   end
 end

--- a/spec/openstates/models/bill_spec.rb
+++ b/spec/openstates/models/bill_spec.rb
@@ -30,4 +30,20 @@ describe OpenStates::Bill do
       end
     end
   end
+
+  describe ".find_by_openstates_id" do
+    context "openstates id is legit" do
+      it "should return a Bill" do
+        expect(OpenStates::Bill.find_by_openstates_id("KSB00005007")).to be_a described_class
+      end
+    end
+
+    context "openstates id is not legit" do
+      it "should raise 404 error" do
+        expect do
+          OpenStates::Bill.find_by_openstates_id("not-real")
+        end.to raise_error Faraday::ResourceNotFound
+      end
+    end
+  end
 end


### PR DESCRIPTION
OpenStates API has its own `id` attribute. This adds a method to fetch details using that value.