### PR TITLE
Update code style

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  ExtraDetails: true
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/NegatedIf:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Style/DotPosition:
+  EnforcedStyle: leading
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: true
+  Max: 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+
+script:
+  - bundle
+  - bundle exec rspec spec
+
+branches:
+  only:
+    - master

--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,0 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-guard :rspec do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/openstates/(.+)\.rb$})     { |m| "spec/openstates/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
-end
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/lib/openstates.rb
+++ b/lib/openstates.rb
@@ -1,5 +1,4 @@
 require 'openstates/core'
 
 module OpenStates
-
 end

--- a/lib/openstates/api.rb
+++ b/lib/openstates/api.rb
@@ -33,7 +33,7 @@ module OpenStates
     def geo_legislators(lat, lon)
       url = "legislators/geo/"
 
-      get(url, {:lat => lat, :long => lon})
+      get(url, {lat: lat, long: lon})
     end
 
     def committees(options = {})

--- a/lib/openstates/api.rb
+++ b/lib/openstates/api.rb
@@ -1,13 +1,13 @@
 module OpenStates
   module Api
     def metadata(state = nil)
-      url = "metadata/"
+      url = 'metadata/'
       url << "#{state}/" if state
       get(url)
     end
 
     def bills(options = {})
-      url = "bills/"
+      url = 'bills/'
       if options[:state] && options[:session] && options[:bill_id]
         url << "#{options[:state]}/#{options[:session]}/#{options[:bill_id]}/"
         [:state, :session, :bill_id].each do |key|
@@ -24,27 +24,27 @@ module OpenStates
     end
 
     def legislators(options = {})
-      url = "legislators/"
+      url = 'legislators/'
       url << "#{options[:leg_id]}/" if options[:leg_id]
 
       get(url, options)
     end
 
     def geo_legislators(lat, lon)
-      url = "legislators/geo/"
+      url = 'legislators/geo/'
 
-      get(url, {lat: lat, long: lon})
+      get(url, lat: lat, long: lon)
     end
 
     def committees(options = {})
-      url = "committees/"
+      url = 'committees/'
       url << "#{options[:committee_id]}/" if options[:committee_id]
 
       get(url, options)
     end
 
     def events(options = {})
-      url = "events/"
+      url = 'events/'
       url << "#{options[:event_id]}/" if options[:event_id]
 
       get(url, options)
@@ -53,7 +53,7 @@ module OpenStates
     def districts(options = {})
       return [] if !options[:state]
 
-      url = "districts/"
+      url = 'districts/'
       url << "#{options[:state]}/"
       url << "#{options[:chamber]}/" if options[:chamber]
 

--- a/lib/openstates/connection.rb
+++ b/lib/openstates/connection.rb
@@ -1,13 +1,15 @@
 module OpenStates
   module Connection
-    BASE_URL = 'https://openstates.org/api/v1/'
+    BASE_URL = 'https://openstates.org/api/v1/'.freeze
+
+    # rubocop:disable Metrics/LineLength, Metrics/AbcSize, Metrics/MethodLength
     def connection
       @connection ||= begin
         conn = Faraday.new(BASE_URL) do |b|
           b.use Faraday::Response::Logger, logger
           b.use FaradayMiddleware::Mashify
           b.use FaradayMiddleware::ParseJson, content_type: 'application/json'
-          b.use FaradayMiddleware::Caching, cache, strip_params: %w[apikey] unless cache.nil?
+          b.use FaradayMiddleware::Caching, cache, strip_params: %w(apikey) unless cache.nil?
           b.response :raise_error
           b.adapter Faraday.default_adapter
         end
@@ -17,6 +19,7 @@ module OpenStates
         conn
       end
     end
+    # rubocop:enable Metrics/LineLength, Metrics/AbcSize, Metrics/MethodLength
 
     def get(path, params = nil)
       response = connection.get(path) do |request|

--- a/lib/openstates/mashify.rb
+++ b/lib/openstates/mashify.rb
@@ -3,7 +3,7 @@ require 'faraday'
 module OpenStates
   class Mashify < Faraday::Response::Middleware
     def on_complete(env)
-      super if Hash === env[:body]
+      super if env[:body].is_a? Hash
     end
 
     def parse(body)

--- a/lib/openstates/model.rb
+++ b/lib/openstates/model.rb
@@ -24,7 +24,7 @@ module OpenStates
       def find(id)
         return if !id
 
-        id_hash = Hash.new
+        id_hash = {}
         id_hash[id_key] = id
         response = OpenStates.send(api_method, id_hash)
 
@@ -52,12 +52,11 @@ module OpenStates
       return unless hash
 
       hash.each do |key, value|
+        next if value.nil?
+
         set_attr_method = "#{key}="
-        unless value.nil?
-          if respond_to?(set_attr_method)
-            self.__send__(set_attr_method, value)
-          end
-        end
+
+        __send__(set_attr_method, value) if respond_to?(set_attr_method)
       end
     end
   end

--- a/lib/openstates/models/bill.rb
+++ b/lib/openstates/models/bill.rb
@@ -50,6 +50,8 @@ module OpenStates
       end
 
       def find_by_openstates_id(os_id)
+        return if !os_id
+
         response = OpenStates.bill(os_id)
 
         from_hash(response)

--- a/lib/openstates/version.rb
+++ b/lib/openstates/version.rb
@@ -1,3 +1,3 @@
 module OpenStates
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'.freeze
 end

--- a/openstates.gemspec
+++ b/openstates.gemspec
@@ -4,26 +4,27 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'openstates/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "openstates"
+  spec.name          = 'openstates'
   spec.version       = OpenStates::VERSION
-  spec.authors       = ["Chris"]
-  spec.email         = ["chris@wideeyelabs.com"]
-  spec.summary       = %q{Ruby gem to interact with the OpenStates API.}
-  spec.description   = %q{Ruby gem to interact with the OpenStates API.}
-  spec.homepage      = "https://github.com/WideEyeLabs"
-  spec.license       = "MIT"
+  spec.authors       = ['Chris']
+  spec.email         = ['chris@wideeyelabs.com']
+  spec.summary       = 'Ruby gem to interact with the OpenStates API.'
+  spec.description   = 'Ruby gem to interact with the OpenStates API.'
+  spec.homepage      = 'https://github.com/WideEyeLabs'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "faraday_middleware"
-  spec.add_dependency "hashie"
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-remote"
-  spec.add_development_dependency "pry-byebug"
+  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'hashie'
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-remote'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rubocop'
 end

--- a/spec/openstates/api_spec.rb
+++ b/spec/openstates/api_spec.rb
@@ -1,46 +1,46 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe OpenStates::Api do
   before(:each) { allow(OpenStates).to receive(:get).and_return({}) }
 
-  describe ".metadata" do
-    it "calls .get on OpenStates" do
+  describe '.metadata' do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.metadata
     end
 
-    context "without a state passed" do
-      it "calls .get with 'metadata/'" do
-        expect(OpenStates).to receive(:get).with("metadata/")
+    context 'without a state passed' do
+      it 'calls .get with metadata/' do
+        expect(OpenStates).to receive(:get).with('metadata/')
         OpenStates.metadata
       end
     end
 
-    context "with a state passed in" do
-      it "calls .get with 'metadata/in/'" do
-        state = "in"
+    context 'with a state passed in' do
+      it 'calls .get with metadata/in/' do
+        state = 'in'
         expect(OpenStates).to receive(:get).with("metadata/#{state}/")
         OpenStates.metadata(state)
       end
     end
   end
 
-  describe ".bills" do
-    it "calls .get on OpenStates" do
+  describe '.bills' do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.bills
     end
 
-    context "without an options hash passed" do
-      it "calls .get with 'bills/' and an empty hash" do
-        expect(OpenStates).to receive(:get).with("bills/", {})
+    context 'without an options hash passed' do
+      it 'calls .get with bills/ and an empty hash' do
+        expect(OpenStates).to receive(:get).with('bills/', {})
         OpenStates.bills
       end
     end
 
-    context "with an options hash passed" do
-      it "calls .get with 'bills/in/summer/10' and an options hash" do
-        options = {state: "in", session: "summer", bill_id: 10}
+    context 'with an options hash passed' do
+      it 'calls .get with bills/in/summer/10 and an options hash' do
+        options = {state: 'in', session: 'summer', bill_id: 10}
         expect(OpenStates).to receive(:get).with(
           "bills/#{options[:state]}/#{options[:session]}/#{options[:bill_id]}/",
           options
@@ -50,21 +50,21 @@ describe OpenStates::Api do
     end
   end
 
-  describe ".legislators" do
-    it "calls .get on OpenStates" do
+  describe '.legislators' do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.legislators
     end
 
-    context "without an options hash passed" do
-      it "calls .get with 'legislators/' and an empty hash" do
-        expect(OpenStates).to receive(:get).with("legislators/", {})
+    context 'without an options hash passed' do
+      it 'calls .get with legislators/ and an empty hash' do
+        expect(OpenStates).to receive(:get).with('legislators/', {})
         OpenStates.legislators
       end
     end
 
-    context "with an options hash passed" do
-      it "calls .get with 'legislators/' and an options hash" do
+    context 'with an options hash passed' do
+      it 'calls .get with legislators/ and an options hash' do
         options = {leg_id: 1}
         expect(OpenStates).to receive(:get)
           .with("legislators/#{options[:leg_id]}/", options)
@@ -73,35 +73,36 @@ describe OpenStates::Api do
     end
   end
 
-  describe ".geo_legislators" do
-    it "calls .get on OpenStates" do
+  describe '.geo_legislators' do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.geo_legislators(nil, nil)
     end
 
-    it "calls .get with 'legislators/geo/' and a hash with lat/lon" do
-      lat, lon = 10,10
+    it 'calls .get with legislators/geo/ and a hash with lat/lon' do
+      lat = 10
+      lon = 10
       expect(OpenStates).to receive(:get)
-        .with("legislators/geo/", {lat: lat, long: lon})
+        .with('legislators/geo/', lat: lat, long: lon)
       OpenStates.geo_legislators(lat, lon)
     end
   end
 
-  describe ".committees" do
-    it "calls .get on OpenStates" do
+  describe '.committees' do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.committees
     end
 
-    context "without an options hash passed" do
-      it "calls .get with 'committees/' and an empty hash" do
-        expect(OpenStates).to receive(:get).with("committees/", {})
+    context 'without an options hash passed' do
+      it 'calls .get with committees/ and an empty hash' do
+        expect(OpenStates).to receive(:get).with('committees/', {})
         OpenStates.committees
       end
     end
 
-    context "with an options hash passed" do
-      it "calls .get with 'committees/' and an options hash" do
+    context 'with an options hash passed' do
+      it 'calls .get with committees/ and an options hash' do
         options = {committee_id: 1}
         expect(OpenStates).to receive(:get)
           .with("committees/#{options[:committee_id]}/", options)
@@ -110,21 +111,21 @@ describe OpenStates::Api do
     end
   end
 
-  describe ".events" do
-    it "calls .get on OpenStates" do
+  describe '.events' do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.events
     end
 
-    context "without an options hash passed" do
-      it "calls .get with 'events/' and an empty hash" do
-        expect(OpenStates).to receive(:get).with("events/", {})
+    context 'without an options hash passed' do
+      it 'calls .get with events/ and an empty hash' do
+        expect(OpenStates).to receive(:get).with('events/', {})
         OpenStates.events
       end
     end
 
-    context "with an options hash passed" do
-      it "calls .get with 'events/' and an options hash" do
+    context 'with an options hash passed' do
+      it 'calls .get with events/ and an options hash' do
         options = {event_id: 1}
         expect(OpenStates).to receive(:get)
           .with("events/#{options[:event_id]}/", options)
@@ -133,34 +134,35 @@ describe OpenStates::Api do
     end
   end
 
-  describe ".districts" do
-    context "without an options hash passed" do
-      it "returns an Array" do
+  describe '.districts' do
+    context 'without an options hash passed' do
+      it 'returns an Array' do
         expect(OpenStates.districts).to be_an Array
       end
 
-      it "returns an empty Array" do
+      it 'returns an empty Array' do
         expect(OpenStates.districts).to be_empty
       end
     end
 
-    context "with an options hash passed" do
-      context "with a state key only" do
-        it "calls .get on OpenStates" do
+    context 'with an options hash passed' do
+      context 'with a state key only' do
+        it 'calls .get on OpenStates' do
           expect(OpenStates).to receive(:get)
           OpenStates.districts(state: 'fl')
         end
 
-        it "calls .get with 'districts/' and an options hash" do
+        it 'calls .get with districts/ and an options hash' do
           options = {state: 'oh'}
-          expect(OpenStates).to receive(:get).with("districts/#{options[:state]}/", options)
+          expect(OpenStates).to receive(:get)
+            .with("districts/#{options[:state]}/", options)
           OpenStates.districts(options)
         end
       end
 
-      context "with a state and chamber key" do
-        it "calls .get with 'districts/' and an options hash" do
-          options = {state: 'in', chamber: "blah"}
+      context 'with a state and chamber key' do
+        it 'calls .get with districts/ and an options hash' do
+          options = {state: 'in', chamber: 'blah'}
           expect(OpenStates).to receive(:get)
             .with("districts/#{options[:state]}/#{options[:chamber]}/", options)
           OpenStates.districts(options)
@@ -169,22 +171,23 @@ describe OpenStates::Api do
     end
   end
 
-  describe ".district_boundaries" do
+  describe '.district_boundaries' do
     let(:boundary_id) { 1 }
-    it "calls .get on OpenStates" do
+    it 'calls .get on OpenStates' do
       expect(OpenStates).to receive(:get)
       OpenStates.district_boundaries(boundary_id)
     end
 
-    context "with a boundary_id parameter" do
-      it "calls .get with 'districts/:boundary_id'" do
-        expect(OpenStates).to receive(:get).with("districts/boundary/#{boundary_id}/")
+    context 'with a boundary_id parameter' do
+      it 'calls .get with districts/:boundary_id' do
+        expect(OpenStates).to receive(:get)
+          .with("districts/boundary/#{boundary_id}/")
         OpenStates.district_boundaries(boundary_id)
       end
     end
 
-    context "without a boundary_id parameter" do
-      it "returns nil" do
+    context 'without a boundary_id parameter' do
+      it 'returns nil' do
         expect(OpenStates.district_boundaries(nil)).to be_nil
       end
     end

--- a/spec/openstates/api_spec.rb
+++ b/spec/openstates/api_spec.rb
@@ -1,23 +1,23 @@
 require "spec_helper"
 
 describe OpenStates::Api do
-  before { OpenStates.stub(:get).and_return({}) }
+  before(:each) { allow(OpenStates).to receive(:get).and_return({}) }
 
   describe ".metadata" do
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.metadata
     end
 
     context "without a state passed" do
-      it "should call .get with 'metadata/'" do
+      it "calls .get with 'metadata/'" do
         expect(OpenStates).to receive(:get).with("metadata/")
         OpenStates.metadata
       end
     end
 
     context "with a state passed in" do
-      it "should call .get with 'metadata/in/'" do
+      it "calls .get with 'metadata/in/'" do
         state = "in"
         expect(OpenStates).to receive(:get).with("metadata/#{state}/")
         OpenStates.metadata(state)
@@ -26,101 +26,108 @@ describe OpenStates::Api do
   end
 
   describe ".bills" do
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.bills
     end
 
     context "without an options hash passed" do
-      it "should call .get with 'bills/' and an empty hash" do
+      it "calls .get with 'bills/' and an empty hash" do
         expect(OpenStates).to receive(:get).with("bills/", {})
         OpenStates.bills
       end
     end
 
     context "with an options hash passed" do
-      it "should call .get with 'bills/in/summer/10' and an options hash" do
-        options = {:state => "in", :session => "summer", :bill_id => 10}
-        expect(OpenStates).to receive(:get).with("bills/#{options[:state]}/#{options[:session]}/#{options[:bill_id]}/", options)
+      it "calls .get with 'bills/in/summer/10' and an options hash" do
+        options = {state: "in", session: "summer", bill_id: 10}
+        expect(OpenStates).to receive(:get).with(
+          "bills/#{options[:state]}/#{options[:session]}/#{options[:bill_id]}/",
+          options
+        )
         OpenStates.bills(options)
       end
     end
   end
 
   describe ".legislators" do
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.legislators
     end
 
     context "without an options hash passed" do
-      it "should call .get with 'legislators/' and an empty hash" do
+      it "calls .get with 'legislators/' and an empty hash" do
         expect(OpenStates).to receive(:get).with("legislators/", {})
         OpenStates.legislators
       end
     end
 
     context "with an options hash passed" do
-      it "should call .get with 'legislators/' and an options hash" do
-        options = {:leg_id => 1}
-        expect(OpenStates).to receive(:get).with("legislators/#{options[:leg_id]}/", options)
+      it "calls .get with 'legislators/' and an options hash" do
+        options = {leg_id: 1}
+        expect(OpenStates).to receive(:get)
+          .with("legislators/#{options[:leg_id]}/", options)
         OpenStates.legislators(options)
       end
     end
   end
 
   describe ".geo_legislators" do
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.geo_legislators(nil, nil)
     end
 
-    it "should call .get with 'legislators/geo/' and a hash with lat/lon" do
+    it "calls .get with 'legislators/geo/' and a hash with lat/lon" do
       lat, lon = 10,10
-      expect(OpenStates).to receive(:get).with("legislators/geo/", {:lat => lat, :long => lon})
+      expect(OpenStates).to receive(:get)
+        .with("legislators/geo/", {lat: lat, long: lon})
       OpenStates.geo_legislators(lat, lon)
     end
   end
 
   describe ".committees" do
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.committees
     end
 
     context "without an options hash passed" do
-      it "should call .get with 'committees/' and an empty hash" do
+      it "calls .get with 'committees/' and an empty hash" do
         expect(OpenStates).to receive(:get).with("committees/", {})
         OpenStates.committees
       end
     end
 
     context "with an options hash passed" do
-      it "should call .get with 'committees/' and an options hash" do
-        options = {:committee_id => 1}
-        expect(OpenStates).to receive(:get).with("committees/#{options[:committee_id]}/", options)
+      it "calls .get with 'committees/' and an options hash" do
+        options = {committee_id: 1}
+        expect(OpenStates).to receive(:get)
+          .with("committees/#{options[:committee_id]}/", options)
         OpenStates.committees(options)
       end
     end
   end
 
   describe ".events" do
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.events
     end
 
     context "without an options hash passed" do
-      it "should call .get with 'events/' and an empty hash" do
+      it "calls .get with 'events/' and an empty hash" do
         expect(OpenStates).to receive(:get).with("events/", {})
         OpenStates.events
       end
     end
 
     context "with an options hash passed" do
-      it "should call .get with 'events/' and an options hash" do
-        options = {:event_id => 1}
-        expect(OpenStates).to receive(:get).with("events/#{options[:event_id]}/", options)
+      it "calls .get with 'events/' and an options hash" do
+        options = {event_id: 1}
+        expect(OpenStates).to receive(:get)
+          .with("events/#{options[:event_id]}/", options)
         OpenStates.events(options)
       end
     end
@@ -128,33 +135,34 @@ describe OpenStates::Api do
 
   describe ".districts" do
     context "without an options hash passed" do
-      it "should return an Array" do
+      it "returns an Array" do
         expect(OpenStates.districts).to be_an Array
       end
 
-      it "should return an empty Array" do
+      it "returns an empty Array" do
         expect(OpenStates.districts).to be_empty
       end
     end
 
     context "with an options hash passed" do
       context "with a state key only" do
-        it "should call .get on OpenStates" do
+        it "calls .get on OpenStates" do
           expect(OpenStates).to receive(:get)
           OpenStates.districts(state: 'fl')
         end
 
-        it "should call .get with 'districts/' and an options hash" do
-          options = {:state => 'oh'}
+        it "calls .get with 'districts/' and an options hash" do
+          options = {state: 'oh'}
           expect(OpenStates).to receive(:get).with("districts/#{options[:state]}/", options)
           OpenStates.districts(options)
         end
       end
 
       context "with a state and chamber key" do
-        it "should call .get with 'districts/' and an options hash" do
-          options = {:state => 'in', :chamber => "blah"}
-          expect(OpenStates).to receive(:get).with("districts/#{options[:state]}/#{options[:chamber]}/", options)
+        it "calls .get with 'districts/' and an options hash" do
+          options = {state: 'in', chamber: "blah"}
+          expect(OpenStates).to receive(:get)
+            .with("districts/#{options[:state]}/#{options[:chamber]}/", options)
           OpenStates.districts(options)
         end
       end
@@ -163,20 +171,20 @@ describe OpenStates::Api do
 
   describe ".district_boundaries" do
     let(:boundary_id) { 1 }
-    it "should call .get on OpenStates" do
+    it "calls .get on OpenStates" do
       expect(OpenStates).to receive(:get)
       OpenStates.district_boundaries(boundary_id)
     end
 
     context "with a boundary_id parameter" do
-      it "should call .get with 'districts/:boundary_id'" do
+      it "calls .get with 'districts/:boundary_id'" do
         expect(OpenStates).to receive(:get).with("districts/boundary/#{boundary_id}/")
         OpenStates.district_boundaries(boundary_id)
       end
     end
 
     context "without a boundary_id parameter" do
-      it "should return nil" do
+      it "returns nil" do
         expect(OpenStates.district_boundaries(nil)).to be_nil
       end
     end

--- a/spec/openstates/models/bill_spec.rb
+++ b/spec/openstates/models/bill_spec.rb
@@ -2,47 +2,60 @@ require 'spec_helper'
 
 describe OpenStates::Bill do
   describe ".api_method" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Bill.api_method }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Bill.api_method }.not_to raise_error
     end
   end
 
   describe ".id_key" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Bill.id_key }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Bill.id_key }.not_to raise_error
     end
   end
 
   describe ".bill_details" do
     context "when state, session, and bill_id are nil" do
-      it "should return nil" do
+      it "returns nil" do
         expect(OpenStates::Bill.bill_details(nil, nil, nil)).to be_nil
       end
     end
 
     context "when state, session, and bill_id are not nil" do
-      it "should return an OpenState::Bill" do
+      it "returns an OpenState::Bill" do
         state = 'fl'
         session = '2013'
         bill_id = '1234'
-        OpenStates.stub(:bills).and_return({:bill_id => bill_id, :state => state, :session => session})
-        OpenStates::Bill.bill_details(state, session, bill_id).should be_a OpenStates::Bill
+
+        allow(OpenStates).to receive(:bills).and_return(
+          {bill_id: bill_id, state: state, session: session}
+        )
+
+        expect(
+          OpenStates::Bill.bill_details(state, session, bill_id)
+        ).to be_a described_class
       end
     end
   end
 
   describe ".find_by_openstates_id" do
     context "openstates id is legit" do
-      it "should return a Bill" do
-        expect(OpenStates::Bill.find_by_openstates_id("KSB00005007")).to be_a described_class
+      it "returns a Bill" do
+
+        openstate_bill_id = 'KSB00005007'
+
+        allow(OpenStates).to receive(:bill).and_return(
+          {id: openstate_bill_id}
+        )
+
+        expect(
+          OpenStates::Bill.find_by_openstates_id("KSB00005007")
+        ).to be_a described_class
       end
     end
 
-    context "openstates id is not legit" do
-      it "should raise 404 error" do
-        expect do
-          OpenStates::Bill.find_by_openstates_id("not-real")
-        end.to raise_error Faraday::ResourceNotFound
+    context "when openstate_bill_id is nil" do
+      it "returns nil" do
+        expect(OpenStates::Bill.find_by_openstates_id(nil)).to be_nil
       end
     end
   end

--- a/spec/openstates/models/bill_spec.rb
+++ b/spec/openstates/models/bill_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
 describe OpenStates::Bill do
-  describe ".api_method" do
-    it "does not raise a NotImplementedError" do
+  describe '.api_method' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Bill.api_method }.not_to raise_error
     end
   end
 
-  describe ".id_key" do
-    it "does not raise a NotImplementedError" do
+  describe '.id_key' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Bill.id_key }.not_to raise_error
     end
   end
 
-  describe ".bill_details" do
-    context "when state, session, and bill_id are nil" do
-      it "returns nil" do
+  describe '.bill_details' do
+    context 'when state, session, and bill_id are nil' do
+      it 'returns nil' do
         expect(OpenStates::Bill.bill_details(nil, nil, nil)).to be_nil
       end
     end
 
-    context "when state, session, and bill_id are not nil" do
-      it "returns an OpenState::Bill" do
+    context 'when state, session, and bill_id are not nil' do
+      it 'returns an OpenState::Bill' do
         state = 'fl'
         session = '2013'
         bill_id = '1234'
 
         allow(OpenStates).to receive(:bills).and_return(
-          {bill_id: bill_id, state: state, session: session}
+          bill_id: bill_id, state: state, session: session
         )
 
         expect(
@@ -37,24 +37,23 @@ describe OpenStates::Bill do
     end
   end
 
-  describe ".find_by_openstates_id" do
-    context "openstates id is legit" do
-      it "returns a Bill" do
-
+  describe '.find_by_openstates_id' do
+    context 'openstates id is legit' do
+      it 'returns a Bill' do
         openstate_bill_id = 'KSB00005007'
 
         allow(OpenStates).to receive(:bill).and_return(
-          {id: openstate_bill_id}
+          id: openstate_bill_id
         )
 
         expect(
-          OpenStates::Bill.find_by_openstates_id("KSB00005007")
+          OpenStates::Bill.find_by_openstates_id('KSB00005007')
         ).to be_a described_class
       end
     end
 
-    context "when openstate_bill_id is nil" do
-      it "returns nil" do
+    context 'when openstate_bill_id is nil' do
+      it 'returns nil' do
         expect(OpenStates::Bill.find_by_openstates_id(nil)).to be_nil
       end
     end

--- a/spec/openstates/models/committee_spec.rb
+++ b/spec/openstates/models/committee_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe OpenStates::Committee do
   describe ".api_method" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Committee.api_method }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Committee.api_method }.not_to raise_error
     end
   end
 
   describe ".id_key" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Committee.id_key }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Committee.id_key }.not_to raise_error
     end
   end
 end

--- a/spec/openstates/models/committee_spec.rb
+++ b/spec/openstates/models/committee_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe OpenStates::Committee do
-  describe ".api_method" do
-    it "does not raise a NotImplementedError" do
+  describe '.api_method' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Committee.api_method }.not_to raise_error
     end
   end
 
-  describe ".id_key" do
-    it "does not raise a NotImplementedError" do
+  describe '.id_key' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Committee.id_key }.not_to raise_error
     end
   end

--- a/spec/openstates/models/district_spec.rb
+++ b/spec/openstates/models/district_spec.rb
@@ -2,31 +2,31 @@ require 'spec_helper'
 
 describe OpenStates::District do
   describe ".api_method" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::District.api_method }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::District.api_method }.not_to raise_error
     end
   end
 
   describe ".id_key" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::District.id_key }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::District.id_key }.not_to raise_error
     end
   end
 
   describe ".find" do
     before(:each) do
-      OpenStates.stub(:district_boundaries).and_return({ :state => 'il' })
+      allow(OpenStates).to receive(:district_boundaries).and_return({state: 'il'})
     end
 
     context "without a boundary id" do
-      it "should return nil" do
+      it "returns nil" do
         expect(OpenStates::District.find(nil)).to be_nil
       end
     end
 
     context "with a boundary id" do
-      it "should return an OpenState::District" do
-        options = { :state => 'il' }
+      it "returns an OpenState::District" do
+        options = {state: 'il'}
         expect(OpenStates::District.find(options)).to be_a OpenStates::District
       end
     end

--- a/spec/openstates/models/district_spec.rb
+++ b/spec/openstates/models/district_spec.rb
@@ -1,33 +1,34 @@
 require 'spec_helper'
 
 describe OpenStates::District do
-  describe ".api_method" do
-    it "does not raise a NotImplementedError" do
+  describe '.api_method' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::District.api_method }.not_to raise_error
     end
   end
 
-  describe ".id_key" do
-    it "does not raise a NotImplementedError" do
+  describe '.id_key' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::District.id_key }.not_to raise_error
     end
   end
 
-  describe ".find" do
+  describe '.find' do
     before(:each) do
-      allow(OpenStates).to receive(:district_boundaries).and_return({state: 'il'})
+      allow(OpenStates).to receive(:district_boundaries)
+        .and_return(state: 'il')
     end
 
-    context "without a boundary id" do
-      it "returns nil" do
+    context 'without a boundary id' do
+      it 'returns nil' do
         expect(OpenStates::District.find(nil)).to be_nil
       end
     end
 
-    context "with a boundary id" do
-      it "returns an OpenState::District" do
+    context 'with a boundary id' do
+      it 'returns an OpenState::District' do
         options = {state: 'il'}
-        expect(OpenStates::District.find(options)).to be_a OpenStates::District
+        expect(OpenStates::District.find(options)).to be_a described_class
       end
     end
   end

--- a/spec/openstates/models/event_spec.rb
+++ b/spec/openstates/models/event_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe OpenStates::Event do
   describe ".api_method" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Event.api_method }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Event.api_method }.not_to raise_error
     end
   end
 
   describe ".id_key" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Event.id_key }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Event.id_key }.not_to raise_error
     end
   end
 end

--- a/spec/openstates/models/event_spec.rb
+++ b/spec/openstates/models/event_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe OpenStates::Event do
-  describe ".api_method" do
-    it "does not raise a NotImplementedError" do
+  describe '.api_method' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Event.api_method }.not_to raise_error
     end
   end
 
-  describe ".id_key" do
-    it "does not raise a NotImplementedError" do
+  describe '.id_key' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Event.id_key }.not_to raise_error
     end
   end

--- a/spec/openstates/models/legislator_spec.rb
+++ b/spec/openstates/models/legislator_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe OpenStates::Legislator do
   describe ".api_method" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Legislator.api_method }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Legislator.api_method }.not_to raise_error
     end
   end
 
   describe ".id_key" do
-    it "should not raise a NotImplementedError" do
-      expect{ OpenStates::Legislator.id_key }.not_to raise_error
+    it "does not raise a NotImplementedError" do
+      expect { OpenStates::Legislator.id_key }.not_to raise_error
     end
   end
 
   describe ".by_location" do
     context "when lat and lon are nil" do
-      it "should return nil" do
-        OpenStates::Legislator.by_location(nil,nil).should be_nil
+      it "does return nil" do
+        expect(OpenStates::Legislator.by_location(nil,nil)).to be_nil
       end
     end
 
@@ -24,16 +24,16 @@ describe OpenStates::Legislator do
       before(:each) do
         legislator_hash = {leg_id: '1', first_name: 'bob'}
         response = [legislator_hash, legislator_hash]
-        OpenStates.stub(:geo_legislators).and_return(response)
+        allow(OpenStates).to receive(:geo_legislators).and_return(response)
       end
 
-      it "should return an array" do
-        OpenStates::Legislator.by_location(123.10, -85.20).should be_an Array
+      it "does return an array" do
+        expect(OpenStates::Legislator.by_location(123.10, -85.20)).to be_an Array
       end
 
-      it "should return an array of legislator objects" do
+      it "does return an array of legislator objects" do
         OpenStates::Legislator.by_location(123.10, -85.20).each do |obj|
-          obj.should be_a OpenStates::Legislator
+          expect(obj).to be_a OpenStates::Legislator
         end
       end
     end

--- a/spec/openstates/models/legislator_spec.rb
+++ b/spec/openstates/models/legislator_spec.rb
@@ -1,37 +1,39 @@
 require 'spec_helper'
 
 describe OpenStates::Legislator do
-  describe ".api_method" do
-    it "does not raise a NotImplementedError" do
+  describe '.api_method' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Legislator.api_method }.not_to raise_error
     end
   end
 
-  describe ".id_key" do
-    it "does not raise a NotImplementedError" do
+  describe '.id_key' do
+    it 'does not raise a NotImplementedError' do
       expect { OpenStates::Legislator.id_key }.not_to raise_error
     end
   end
 
-  describe ".by_location" do
-    context "when lat and lon are nil" do
-      it "does return nil" do
-        expect(OpenStates::Legislator.by_location(nil,nil)).to be_nil
+  describe '.by_location' do
+    context 'when lat and lon are nil' do
+      it 'does return nil' do
+        expect(OpenStates::Legislator.by_location(nil, nil)).to be_nil
       end
     end
 
-    context "when lat and lon are not nil" do
+    context 'when lat and lon are not nil' do
       before(:each) do
         legislator_hash = {leg_id: '1', first_name: 'bob'}
         response = [legislator_hash, legislator_hash]
         allow(OpenStates).to receive(:geo_legislators).and_return(response)
       end
 
-      it "does return an array" do
-        expect(OpenStates::Legislator.by_location(123.10, -85.20)).to be_an Array
+      it 'does return an array' do
+        expect(
+          OpenStates::Legislator.by_location(123.10, -85.20)
+        ).to be_an Array
       end
 
-      it "does return an array of legislator objects" do
+      it 'does return an array of legislator objects' do
         OpenStates::Legislator.by_location(123.10, -85.20).each do |obj|
           expect(obj).to be_a OpenStates::Legislator
         end

--- a/spec/openstates/version_spec.rb
+++ b/spec/openstates/version_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe OpenStates::VERSION do
-  it "should return a version string" do
-    OpenStates::VERSION.class.should == String
+  it "Returns a version string" do
+    expect(OpenStates::VERSION.class).to eq(String)
   end
 end
 

--- a/spec/openstates/version_spec.rb
+++ b/spec/openstates/version_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe OpenStates::VERSION do
-  it "Returns a version string" do
+  it 'returns a version string' do
     expect(OpenStates::VERSION.class).to eq(String)
   end
 end
-
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,12 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
 require 'openstates'
 require 'pry'
 require 'pry-remote'
-require 'pry-debugger'
+require 'pry-byebug'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'


### PR DESCRIPTION
In order to ensure a consistent style throughout the codebase, this
pull request adds the rubocop gem and a configuration file. It also instructs
houndci to use the rubocop configuration to ensure it's enforced on pull
requests. In addition, it updates the code to pass rubocop inspection. It also
makes the specs more confident by replacing should with expect and updating
the descriptions in the spec test to follow suit. Finally it upgrades rspec and
friends to newer versions.