### PR TITLE
Update version to 0.2.0 and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Change Log
+
+## 0.x Releases
+- `0.2.x` Releases - [0.2.0](#020)
+- `0.1.x` Releases - [0.1.0](#010)
+
+## 0.0.x Releases
+- `0.0.x` Releases - [0.0.1](#001)
+
+---
+## [0.2.0](https://github.com/wideeyelabs/ruby-openstates/releases/tag/v0.2.0)
+Released on 2017-02-17
+
+### Added
+Added the ability to fetch a single bill detail via the OpenStates id
+
+### Updated
+- Style consistency throughout the codebase
+
+### Removed
+
+
+## [0.1.0](https://github.com/wideeyelabs/ruby-openstates/releases/tag/v0.1.0)
+Released on 2017-01-06
+
+### Added
+
+### Updated
+- Use https instead of http
+
+### Removed
+
+
+## [0.0.1](https://github.com/wideeyelabs/ruby-openstates/releases/tag/v0.0.1)
+Released on 2013-12-01
+
+Initial Release

--- a/lib/openstates/version.rb
+++ b/lib/openstates/version.rb
@@ -1,3 +1,3 @@
 module OpenStates
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
In order to keep track of whats changed in each new version, this commit
adds a CHANGELOG. It also updates the version number to 0.2.0.